### PR TITLE
Fixed Error of unicode encoding

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,7 @@ name: testing
 
 on:
   push:
+  pull_request:
 
 jobs:
   test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "st-pages"
-version = "0.3.0"
+version = "0.3.1"
 description = "An experimental version of Streamlit Multi-Page Apps"
 authors = ["Zachary Blackwood <zachary@streamlit.io>"]
 readme = "README.md"

--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -197,9 +197,9 @@ def _get_pages_from_config(path: str = ".streamlit/pages.toml") -> list[Page] | 
     Given a path to a TOML file, read the file and return a list of Page objects
     """
     try:
-        raw_pages: list[dict[str, str | bool]] = toml.loads(Path(path).read_text(encoding='utf-8'))[
-            "pages"
-        ]
+        raw_pages: list[dict[str, str | bool]] = toml.loads(
+            Path(path).read_text(encoding="utf-8")
+        )["pages"]
     except (FileNotFoundError, toml.decoder.TomlDecodeError, KeyError):
         st.error(
             f"""

--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -197,7 +197,7 @@ def _get_pages_from_config(path: str = ".streamlit/pages.toml") -> list[Page] | 
     Given a path to a TOML file, read the file and return a list of Page objects
     """
     try:
-        raw_pages: list[dict[str, str | bool]] = toml.loads(Path(path).read_text())[
+        raw_pages: list[dict[str, str | bool]] = toml.loads(Path(path).read_text(encoding='utf-8'))[
             "pages"
         ]
     except (FileNotFoundError, toml.decoder.TomlDecodeError, KeyError):


### PR DESCRIPTION
Fixed the Error of unsupported Unicode encoding in Windows while reading the `pages.toml` file.

**Before:**
![image](https://user-images.githubusercontent.com/19536819/210192072-5ba6871c-1906-4d63-bf3c-628a54a9f4e8.png)

**After:**
![image](https://user-images.githubusercontent.com/19536819/210192130-96a981fb-8f0e-4e72-a6c2-32572de1019b.png)
