### PR TITLE
Better usability for devices without internet connection.

### DIFF
--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -91,11 +91,11 @@ def translate_icon(icon: str) -> str:
     If you pass a name of an icon, like :dog:, translate it into the
     corresponding unicode character
     """
-    icons = get_icons()
     if icon == "random":
         icon = get_random_emoji()
     elif icon.startswith(":") and icon.endswith(":"):
         icon = icon[1:-1]
+        icons = get_icons()
         if icon in icons:
             return icons[icon]
     return icon


### PR DESCRIPTION
Hi @blackary,

this pull request only moves the `get_icons()` call to the scope where it is needed. Now `get_icons()` will only be called when there is an icon which starts with `:` and ends with `:`. All other possible icons (e.g. by using emojis) will now work without an internet connection.

Fixes this error:
<img width="759" alt="Bildschirm­foto 2023-02-21 um 16 06 20" src="https://user-images.githubusercontent.com/67844154/220382112-40c54a10-056a-4cf3-aff6-768e72b428cf.png">

