### PR TITLE
Ensure sidebar formatting only occurs within Sidebar div

### DIFF
--- a/example_app/example_four.py
+++ b/example_app/example_four.py
@@ -17,3 +17,5 @@ elif selection == "Hide pages 1 and 2":
     hide_pages(["Example One", "Example Two"])
 elif selection == "Hide Other apps Section":
     hide_pages(["Other apps"])
+
+st.selectbox("test_select", options=["1", "2", "3"])

--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -296,7 +296,7 @@ def _get_indentation_code() -> str:
     for idx, val in enumerate(current_pages.values()):
         if val.get("is_section"):
             styling += f"""
-                li:nth-child({idx + 1}) a {{
+                div[data-testid=\"stSidebarNav\"] li:nth-child({idx + 1}) a {{
                     pointer-events: none; /* Disable clicking on section header */
                 }}
             """
@@ -308,7 +308,7 @@ def _get_indentation_code() -> str:
         elif is_indented:
             # Unless specifically unnested, indent all pages that aren't section headers
             styling += f"""
-                li:nth-child({idx + 1}) span:nth-child(1) {{
+                div[data-testid=\"stSidebarNav\"] li:nth-child({idx + 1}) span:nth-child(1) {{
                     margin-left: 1.5rem;
                 }}
             """
@@ -361,7 +361,7 @@ def _get_page_hiding_code(pages_to_hide: list[str]) -> str:
             section_hidden = False
         if page_name in pages_to_hide or section_hidden:
             styling += f"""
-                li:nth-child({idx + 1}) {{
+                div[data-testid=\"stSidebarNav\"] li:nth-child({idx + 1}) {{
                     display: none;
                 }}
             """

--- a/tests/test_frontend_sections.py
+++ b/tests/test_frontend_sections.py
@@ -143,3 +143,10 @@ def test_page_hiding(page: Page):
         .filter(has_text="🐴Other apps")
     ).to_be_visible()
     expect(page.get_by_role("link", name="Example three")).to_be_visible()
+
+
+def test_selectbox(page: Page):
+    page.get_by_role("link", name="Example Four").click()
+    page.get_by_text("Hide pages 1 and 2").click()
+    page.get_by_text("test_select1open").click()
+    expect(page.get_by_role("option", name="2")).to_be_visible()


### PR DESCRIPTION
I saw #38 and realised that all the formatting is being applied to all list items.

I think [in my tests] the following should hide items from sidebar, without impacting other select boxes