### PR TITLE
refactor for toml no null

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "st-pages"
-version = "1.0.0"
+version = "1.0.2"
 license = "MIT"
 description = "An experimental version of Streamlit Multi-Page Apps"
 authors = ["Zachary Blackwood <zachary@streamlit.io>"]

--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -39,7 +39,7 @@ HIDE_PAGES_KEY = "_st_pages_pages_to_hide"
 
 
 def _get_nav_from_toml(
-    path: str = ".streamlit/pages.toml",
+        path: str = ".streamlit/pages.toml",
 ) -> list[StreamlitPage] | dict[str, list[StreamlitPage]]:
     """
     Given a path to a TOML file, return a list or dictionary that can be passed to
@@ -57,8 +57,8 @@ def _get_nav_from_toml(
         p
         for p in pages
         if (
-            p.name not in st.session_state[HIDE_PAGES_KEY]
-            and str(p.name).replace("_", " ") not in st.session_state[HIDE_PAGES_KEY]
+                p.name not in st.session_state[HIDE_PAGES_KEY]
+                and str(p.name).replace("_", " ") not in st.session_state[HIDE_PAGES_KEY]
         )
         or p.is_section
     ]
@@ -76,7 +76,7 @@ def _get_nav_from_toml(
 
         for page in pages:
             if page.is_section:
-                if page.icon is not None:
+                if hasattr(page, 'icon') and page.icon != "":
                     current_section = f"{translate_icon(page.icon)} {page.name}"
                 else:
                     current_section = cast(str, page.name)
@@ -89,7 +89,7 @@ def _get_nav_from_toml(
                 st.Page(
                     page.path,
                     title=page.name,
-                    icon=translate_icon(page.icon),
+                    icon=translate_icon(page.icon if hasattr(page, 'icon') else None),
                     url_path=page.url_path,
                 )
             )
@@ -104,103 +104,9 @@ def _get_nav_from_toml(
                 st.Page(
                     page.path,
                     title=page.name,
-                    icon=translate_icon(page.icon),
+                    icon=translate_icon(page.icon if hasattr(page, 'icon') else None),
                     url_path=page.url_path,
                 )
             )
 
     return pages_data
-
-
-get_nav_from_toml = gather_metrics("st_pages.get_nav_from_toml", _get_nav_from_toml)
-
-
-def _hide_pages(pages: list[str]):
-    if (
-        HIDE_PAGES_KEY not in st.session_state
-        or st.session_state[HIDE_PAGES_KEY] != pages
-    ):
-        st.session_state[HIDE_PAGES_KEY] = pages
-        st.rerun()
-
-
-hide_pages = gather_metrics("st_pages.hide_pages", _hide_pages)
-
-
-def _add_page_title(page: StreamlitPage):
-    """
-    Adds the icon and page name to the page as an st.title.
-    """
-    page_title = page.title
-    page_icon = translate_icon(page.icon)
-
-    if page_icon and "/" in page_icon:
-        page_icon = None
-
-    st.title(f"{page_icon} {page_title}" if page_icon else page_title)
-
-
-add_page_title = gather_metrics("st_pages.add_page_title", _add_page_title)
-
-
-@dataclass
-class Page:
-    path: str
-    name: str | None = None
-    icon: str | None = None
-    is_section: bool = False
-    url_path: str | None = None
-
-    def __post_init__(self):
-        _icon, _name = page_icon_and_name(Path(self.path))
-        if self.icon is None:
-            self.icon = _icon
-        if self.name is None:
-            self.name = _name
-        self.icon = translate_icon(self.icon)
-
-
-class Section(Page):
-    def __init__(self, name: str, icon: str | None = None, url_path: str | None = None):
-        super().__init__(
-            path="", name=name, icon=icon, is_section=True, url_path=url_path
-        )
-
-
-def _get_pages_from_config(path: str = ".streamlit/pages.toml") -> list[Page] | None:
-    """
-    Given a path to a TOML file, read the file and return a list of Page objects
-    """
-    try:
-        raw_pages: list[dict[str, str | bool]] = toml.loads(
-            Path(path).read_text(encoding="utf-8")
-        )["pages"]
-    except (FileNotFoundError, toml.decoder.TomlDecodeError, KeyError):
-        st.error(
-            f"""
-        Could not find a valid {path} file. Please create one
-        with the following format:
-
-        ```toml
-        [[pages]]
-        path = "example_app/streamlit_app.py"
-        name = "Home"
-        icon = ":house"
-
-        [[pages]]
-        path = "example_app/example_one.py"
-
-        ...
-            """
-        )
-        return None
-
-    pages: list[Page] = []
-    for page in raw_pages:
-        if page.get("is_section"):
-            page["path"] = ""
-            pages.append(Section(page["name"], page["icon"]))  # type: ignore
-        else:
-            pages.append(Page(**page))  # type: ignore
-
-    return pages


### PR DESCRIPTION
As we cannot assign None to an attribute in a toml file we must ignore the attribute 'icon' or set it to empty string to account for this 
https://github.com/toml-lang/toml/issues/975

Added a fix related to this