### PR TITLE
Preserve unrecognized emoji shortcodes in `translate_icon` instead of stripping colons

### DIFF
--- a/src/st_pages/__init__.py
+++ b/src/st_pages/__init__.py
@@ -30,8 +30,12 @@ def translate_icon(icon: str | None) -> str | None:
     if icon == "random":
         icon = get_random_emoji()
     elif icon.startswith(":") and icon.endswith(":") and ":material/" not in icon:
-        icon = icon[1:-1]
-        icon = get_icons().get(icon, icon)
+        shortcode = icon[1:-1]
+        # Only substitute when the shortcode is recognized. For an unknown
+        # shortcode, keep the original ``:shortcode:`` string rather than a
+        # colon-stripped fragment, so Streamlit's validation error references
+        # the user's actual input instead of a mangled value.
+        icon = get_icons().get(shortcode, icon)
     return icon
 
 

--- a/tests/test_streamlit_pages.py
+++ b/tests/test_streamlit_pages.py
@@ -27,3 +27,20 @@ def test_material_icon():
 
     page = Page("tests/test_streamlit_pages.py", icon=":material/refresh:")
     assert page.icon == ":material/refresh:"
+
+
+def test_unknown_shortcode_is_preserved():
+    from st_pages import translate_icon
+
+    # An unrecognized shortcode must keep its colons rather than being
+    # silently reduced to a colon-stripped fragment. Streamlit validates
+    # icons downstream, and preserving the original input keeps its error
+    # message (and the value stored on the page) faithful to what the user
+    # actually passed in.
+    assert translate_icon(":this_is_not_an_emoji:") == ":this_is_not_an_emoji:"
+
+
+def test_known_shortcode_still_translates():
+    from st_pages import translate_icon
+
+    assert translate_icon(":dog:") == "🐶"


### PR DESCRIPTION
`translate_icon` looks up `:shortcode:` names in the bundled `emoji.json`. When a shortcode is not
found, it currently returns the name with the colons stripped (`:foo:` -> `foo`). That value is
neither a valid emoji nor a shortcode, and when it reaches `st.Page(icon=...)` Streamlit raises a
`StreamlitAPIException` from `validate_emoji` — with an error message that references the mangled
`foo` rather than the `:foo:` the user actually wrote, which makes the failure hard to trace (and
is a likely contributor to reports of example/nav apps crashing on an icon).

This changes the lookup miss to return the original `:shortcode:` string unchanged. Recognized
shortcodes (e.g. `:dog:`) and material icons (e.g. `:material/refresh:`) are unaffected.

Added two unit tests covering the unknown-shortcode and known-shortcode paths. The unknown-shortcode
test fails on the pre-change code and passes after.
